### PR TITLE
Update multitarget support for DotNet 8, 9, and 10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "microsoft.sbom.dotnettool": {
-      "version": "3.0.1",
+      "version": "4.1.4",
       "commands": [
         "sbom-tool"
       ]
     },
     "demaconsulting.spdxtool": {
-      "version": "2.2.0",
+      "version": "2.5.0",
       "commands": [
         "spdx-tool"
       ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,14 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - name: Setup dotnet 6/8
-      uses: actions/setup-dotnet@v4
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          6.x
           8.x          
+          9.x
+          10.x
 
     - name: Restore Tools
       run: >
@@ -37,14 +38,18 @@ jobs:
     - name: Create Drop Folder
       shell: bash
       run: |
-        mkdir -p drop/net6.0
         mkdir -p drop/net8.0
-        cp src/DemaConsulting.DotnetToolWrapper/bin/Release/net6.0/*.dll drop/net6.0
-        cp src/DemaConsulting.DotnetToolWrapper/bin/Release/net6.0/*.runtimeconfig.json drop/net6.0
-        cp src/DemaConsulting.DotnetToolWrapper/bin/Release/net6.0/*.deps.json drop/net6.0
+        mkdir -p drop/net9.0
+        mkdir -p drop/net10.0
         cp src/DemaConsulting.DotnetToolWrapper/bin/Release/net8.0/*.dll drop/net8.0
         cp src/DemaConsulting.DotnetToolWrapper/bin/Release/net8.0/*.runtimeconfig.json drop/net8.0
         cp src/DemaConsulting.DotnetToolWrapper/bin/Release/net8.0/*.deps.json drop/net8.0
+        cp src/DemaConsulting.DotnetToolWrapper/bin/Release/net9.0/*.dll drop/net9.0
+        cp src/DemaConsulting.DotnetToolWrapper/bin/Release/net9.0/*.runtimeconfig.json drop/net9.0
+        cp src/DemaConsulting.DotnetToolWrapper/bin/Release/net9.0/*.deps.json drop/net9.0
+        cp src/DemaConsulting.DotnetToolWrapper/bin/Release/net10.0/*.dll drop/net10.0
+        cp src/DemaConsulting.DotnetToolWrapper/bin/Release/net10.0/*.runtimeconfig.json drop/net10.0
+        cp src/DemaConsulting.DotnetToolWrapper/bin/Release/net10.0/*.deps.json drop/net10.0
 
     - name: Generate SBOM
       run: >
@@ -62,10 +67,11 @@ jobs:
         run-workflow spdx-workflow.yaml
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: build-artifacts
         path: |
           drop/_manifest/spdx_2.2/*.*
-          drop/net6.0/*.*
           drop/net8.0/*.*
+          drop/net9.0/*.*
+          drop/net10.0/*.*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
     
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Download Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: build-artifacts
         path: build-artifacts
@@ -51,15 +51,17 @@ jobs:
     - name: Assemble
       shell: bash
       run: |
-        mkdir -p dist/net6.0
         mkdir -p dist/net8.0
-        cp build-artifacts/net6.0/*.* dist/net6.0
+        mkdir -p dist/net9.0
+        mkdir -p dist/net10.0
         cp build-artifacts/net8.0/*.* dist/net8.0
+        cp build-artifacts/net9.0/*.* dist/net9.0
+        cp build-artifacts/net10.0/*.* dist/net10.0
         cd dist
         zip -r ../DotnetToolWrapper.zip *
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: release-artifacts
         path: |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # About
 
-This project generates a .NET 6.0 and 8.0 console application suitable for use in [Dotnet Tool](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools) packages which wrap native applications.
+This project generates a .NET 8.0, 9.0, and 10.0 console application suitable for use in [Dotnet Tool](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools) packages which wrap native applications.
 
 # Usage
 

--- a/src/DemaConsulting.DotnetToolWrapper/DemaConsulting.DotnetToolWrapper.csproj
+++ b/src/DemaConsulting.DotnetToolWrapper/DemaConsulting.DotnetToolWrapper.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Title>Dotnet Tool Wrapper</Title>


### PR DESCRIPTION
This PR updates the multitarget support for DotNet 8, 9, and 10 - dropping 6 because it has reached EOL and isn't getting security updates.