### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_on_push.yaml
+++ b/.github/workflows/build_on_push.yaml
@@ -26,6 +26,8 @@ jobs:
   build:
     name: Build Artifacts
     needs: quality-checks
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yaml
     with:
       semver: '0.0.0-run.${{ github.run_number }}'


### PR DESCRIPTION
Potential fix for [https://github.com/demaconsulting/DotnetToolWrapper/security/code-scanning/5](https://github.com/demaconsulting/DotnetToolWrapper/security/code-scanning/5)

In general, to fix this type of issue you add an explicit `permissions` block at the workflow root or per job to limit `GITHUB_TOKEN` to the minimum required scopes. Jobs that call reusable workflows (`uses: ./.github/workflows/...`) can and should still declare `permissions`, which become the upper bound for what the reusable workflow can do.

For this specific file, the best minimal change is to add a `permissions` section under the `build` job, similar to `quality-checks`, granting read‑only access to repository contents. This preserves existing behavior for read operations while removing any unnecessary write permissions that might otherwise be inherited from repo defaults. Concretely, in `.github/workflows/build_on_push.yaml`, under `build:` and aligned with `name`, `needs`, and `uses`, insert:

```yaml
    permissions:
      contents: read
```

No extra imports or methods are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
