### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,8 @@ on:
 jobs:
   build:
     name: Build Artifacts
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yaml
     with:
       semver: ${{ inputs.semver }}


### PR DESCRIPTION
Potential fix for [https://github.com/demaconsulting/DotnetToolWrapper/security/code-scanning/3](https://github.com/demaconsulting/DotnetToolWrapper/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block to the `build` job, limiting the `GITHUB_TOKEN` to the minimal capabilities required. Since the job only calls a reusable workflow (`./.github/workflows/build.yaml`) and does not itself perform any repository writes, a safe and generally correct default is `permissions: contents: read`. This ensures that if the reusable workflow relies on reading repository contents via `GITHUB_TOKEN`, it still works, but avoids granting unnecessary write scopes from this caller.

Concretely, in `.github/workflows/release.yaml`, under `jobs:`, within the `build:` job definition, insert a `permissions:` section between `name: Build Artifacts` and `uses: ./.github/workflows/build.yaml`. The block will be:

```yaml
    permissions:
      contents: read
```

No additional imports or external dependencies are required; this is purely a YAML configuration change in the GitHub Actions workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
